### PR TITLE
Change deployment folder from 'docs' to 'articles'

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -45,4 +45,4 @@ jobs:
         with:
           clean: false
           branch: gh-pages
-          folder: docs
+          folder: articles


### PR DESCRIPTION
We don't see a `docs` directory in the gh-pages branch which is the branch where the material that this action is deploying is. We do see an `articles` directory that has html files. So wondering if this change will affect what gets written to the documentation. 
