### PR TITLE
Attempt to fix google form handling 

### DIFF
--- a/R/google-forms.R
+++ b/R/google-forms.R
@@ -179,13 +179,13 @@ extract_google_form_rows <- function(df) {
 
   if (is.data.frame(df)) {
     return(lapply(seq_len(nrow(df)), function(i) {
-      lapply(df, function(col) {
-        if (is.list(col)) {
-          col[[i]]
+        if (is.list(col(df))) {
+            message("evalued the if")
+            df[col(df)[[i,i]],]
         } else {
-          col[[i]]
+            message("went to the else")
+            df[col(df)[[i,i]],]
         }
-      })
     }))
   }
 

--- a/R/google-forms.R
+++ b/R/google-forms.R
@@ -184,7 +184,7 @@ extract_google_form_rows <- function(df) {
             df[col(df)[[i,min(ncol(df), i)]],]
         } else {
             message("went to the else")
-            df[col(df)[[i,min(ncol(df), i)]],]
+            df[i,]
         }
     }))
   }

--- a/R/google-forms.R
+++ b/R/google-forms.R
@@ -181,10 +181,10 @@ extract_google_form_rows <- function(df) {
     return(lapply(seq_len(nrow(df)), function(i) {
         if (is.list(col(df))) {
             message("evalued the if")
-            df[col(df)[[i,i]],]
+            df[col(df)[[i,min(ncol(df), i)]],]
         } else {
             message("went to the else")
-            df[col(df)[[i,i]],]
+            df[col(df)[[i,min(ncol(df), i)]],]
         }
     }))
   }

--- a/R/google-forms.R
+++ b/R/google-forms.R
@@ -114,7 +114,7 @@ get_google_form <- function(form_id, token = NULL, dataformat = "dataframe") {
     metadata <- get_question_metadata(form_info)
 
     if (length(result$response_info$result) > 0) {
-      answers_df <- extract_answers(result)
+      answers_df <- extract_answers(result, metadata = metadata)
     } else {
       answers_df <- "no responses yet"
     }
@@ -172,6 +172,114 @@ get_multiple_forms <- function(form_ids = NULL, token = NULL, dataformat = "data
   all_form_info
 }
 
+extract_google_form_rows <- function(df) {
+  if (is.null(df) || length(df) == 0) {
+    return(list())
+  }
+
+  if (is.data.frame(df)) {
+    return(lapply(seq_len(nrow(df)), function(i) {
+      lapply(df, function(col) {
+        if (is.list(col)) {
+          col[[i]]
+        } else {
+          col[[i]]
+        }
+      })
+    }))
+  }
+
+  if (is.list(df) && !is.null(names(df))) {
+    return(list(df))
+  }
+
+  df
+}
+
+
+extract_form_scalar <- function(x, default = NA) {
+  if (is.null(x) || length(x) == 0) {
+    return(default)
+  }
+
+  if (is.data.frame(x)) {
+    return(extract_form_scalar(x[[1]][[1]], default = default))
+  }
+
+  if (is.list(x) && length(x) == 1) {
+    return(extract_form_scalar(x[[1]], default = default))
+  }
+
+  x[[1]]
+}
+
+
+build_google_form_answer_name <- function(question_id, title) {
+  readable_title <- title
+
+  if (is.null(readable_title) || is.na(readable_title) || readable_title == "") {
+    readable_title <- question_id
+  }
+
+  readable_title <- janitor::make_clean_names(readable_title)
+  paste0(readable_title, "__", question_id, "_answers")
+}
+
+
+extract_question_metadata_rows <- function(item) {
+  item_id <- as.character(extract_form_scalar(item$itemId, NA_character_))
+  item_title <- as.character(extract_form_scalar(item$title, NA_character_))
+  metadata_rows <- list()
+
+  if (!is.null(item$questionItem) && !is.null(item$questionItem$question)) {
+    question <- item$questionItem$question
+    question_id <- as.character(extract_form_scalar(question$questionId, NA_character_))
+    paragraph <- as.logical(extract_form_scalar(question$textQuestion$paragraph, NA))
+    choice_question <- as.character(extract_form_scalar(question$choiceQuestion$type, NA_character_))
+
+    metadata_rows[[length(metadata_rows) + 1]] <- data.frame(
+      question_id = question_id,
+      item_id = item_id,
+      title = item_title,
+      paragraph = paragraph,
+      choice_question = choice_question,
+      text_question = !is.na(paragraph),
+      answer_column = build_google_form_answer_name(question_id, item_title),
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+  }
+
+  if (!is.null(item$questionGroupItem) && !is.null(item$questionGroupItem$questions)) {
+    group_questions <- extract_google_form_rows(item$questionGroupItem$questions)
+
+    for (question in group_questions) {
+      question_id <- as.character(extract_form_scalar(question$questionId, NA_character_))
+      row_title <- as.character(extract_form_scalar(question$rowQuestion$title, NA_character_))
+      question_title <- item_title
+
+      if (!is.na(row_title) && row_title != "") {
+        question_title <- paste(item_title, row_title, sep = " - ")
+      }
+
+      metadata_rows[[length(metadata_rows) + 1]] <- data.frame(
+        question_id = question_id,
+        item_id = item_id,
+        title = question_title,
+        paragraph = as.logical(extract_form_scalar(question$textQuestion$paragraph, NA)),
+        choice_question = as.character(extract_form_scalar(question$choiceQuestion$type, NA_character_)),
+        text_question = !is.na(extract_form_scalar(question$textQuestion$paragraph, NA)),
+        answer_column = build_google_form_answer_name(question_id, question_title),
+        stringsAsFactors = FALSE,
+        check.names = FALSE
+      )
+    }
+  }
+
+  metadata_rows
+}
+
+
 #' Google Form handling functions
 #' @description This is a function to get metadata about a Google Form. It is
 #'  used by the `get_google_form()` function if dataformat = "dataframe".
@@ -179,76 +287,135 @@ get_multiple_forms <- function(form_ids = NULL, token = NULL, dataformat = "data
 #' @returns This returns metadata from a google form
 #' @export
 get_question_metadata <- function(form_info) {
-  metadata <- data.frame(
-    question_id = form_info$result$items$itemId,
-    title = form_info$result$items$title
-  )
+  item_rows <- extract_google_form_rows(form_info$result$items)
 
-  if (length(form_info$result$items$questionItem$question$textQuestion) > 0) {
-    metadata <- data.frame(
-      metadata,
-      paragraph = form_info$result$items$questionItem$question$textQuestion
-    )
-  }
-  if (length(form_info$result$items$questionItem$question$choiceQuestion$type) > 0) {
-    metadata <- data.frame(
-      metadata,
-      choice_question = form_info$result$items$questionItem$question$choiceQuestion$type,
-      text_question = is.na(form_info$result$items$questionItem$question$choiceQuestion$type)
-    )
+  if (length(item_rows) == 0) {
+    return(data.frame())
   }
 
-  return(metadata)
+  metadata <- lapply(item_rows, extract_question_metadata_rows)
+  metadata <- metadata[lengths(metadata) > 0]
+  metadata <- unlist(metadata, recursive = FALSE, use.names = FALSE)
+
+  if (length(metadata) == 0) {
+    return(data.frame())
+  }
+
+  metadata <- dplyr::bind_rows(metadata)
+  metadata <- metadata[!is.na(metadata$question_id), , drop = FALSE]
+  rownames(metadata) <- NULL
+
+  metadata
 }
 
 #' Google Form handling functions -- extracting answers
 #' @description This is a function to get extract answers from a Google Form. It is
 #'  used by the `get_google_form()` function if dataformat = "dataframe"
 #' @param form_info The return form_info list that is extracted in `get_google_form()`
+#' @param metadata Optional metadata returned by `get_question_metadata()`
 #' @export
 #' @returns This returns answers from a google form
-extract_answers <- function(form_info) {
-  questions <- form_info$response_info$result$responses$answers
+extract_answers <- function(form_info, metadata = NULL) {
+  responses <- extract_google_form_rows(form_info$response_info$result$responses)
 
-  if (length(questions) > 0) {
-    # Extract the bits we want
-    answers <- purrr::map(
-      questions,
-      ~ .x$textAnswers$answers
-    )
-
-    question_id <- purrr::map(
-      questions,
-      ~ .x$questionId
-    )
-
-    # Reformat the answer info
-    answers <- purrr::map_depth(answers, 2, ~ ifelse(is.null(.x),
-      data.frame(value = "NA"),
-      .x
-    ))
-
-    answers <- purrr::map_depth(answers, -1, ~ ifelse(length(.x) > 1,
-      paste0(.x, collapse = "|"),
-      .x
-    ))
-    answers <- lapply(answers, purrr::map, -1)
-
-    # Turn into data frames
-    answers_df <- lapply(answers, paste0) %>% dplyr::bind_cols()
-
-    colnames(answers_df) <- paste0(colnames(answers_df), "_answers")
-
-    # Put it all in a data.frame we will keep
-    info_df <- data.frame(
-      response_id = rep(form_info$response_info$result$responses$responseId, length(questions)),
-      answers_df
-    )
-  } else {
-    info_df <- data.frame(value = "no responses yet")
+  if (length(responses) == 0) {
+    return(data.frame(value = "no responses yet"))
   }
 
-  return(info_df)
+  if (is.null(metadata)) {
+    metadata <- get_question_metadata(form_info$form_metadata)
+  }
+
+  metadata_lookup <- stats::setNames(metadata$answer_column, metadata$question_id)
+
+  collapse_text_answers <- function(answer) {
+    answer_values <- answer$textAnswers$answers
+
+    if (is.null(answer_values) || length(answer_values) == 0) {
+      return(NA_character_)
+    }
+
+    if (is.data.frame(answer_values) && "value" %in% names(answer_values)) {
+      values <- answer_values$value
+    } else {
+      values <- vapply(answer_values, function(single_answer) {
+        as.character(extract_form_scalar(single_answer$value, NA_character_))
+      }, character(1))
+    }
+
+    paste(values, collapse = "|")
+  }
+
+  collapse_file_upload_answers <- function(answer) {
+    uploaded_files <- answer$fileUploadAnswers$answers
+
+    if (is.null(uploaded_files) || length(uploaded_files) == 0) {
+      return(NA_character_)
+    }
+
+    if (is.data.frame(uploaded_files)) {
+      file_names <- uploaded_files$fileName
+      if (is.null(file_names)) {
+        file_names <- uploaded_files$fileId
+      }
+      return(paste(file_names, collapse = "|"))
+    }
+
+    file_names <- vapply(uploaded_files, function(single_file) {
+      file_name <- extract_form_scalar(single_file$fileName, NA_character_)
+      if (is.na(file_name)) {
+        file_name <- extract_form_scalar(single_file$fileId, NA_character_)
+      }
+      as.character(file_name)
+    }, character(1))
+
+    paste(file_names, collapse = "|")
+  }
+
+  extract_single_answer <- function(answer) {
+    if (!is.null(answer$textAnswers)) {
+      return(collapse_text_answers(answer))
+    }
+
+    if (!is.null(answer$fileUploadAnswers)) {
+      return(collapse_file_upload_answers(answer))
+    }
+
+    NA_character_
+  }
+
+  response_rows <- lapply(responses, function(response) {
+    response_row <- list(
+      response_id = as.character(extract_form_scalar(response$responseId, NA_character_))
+    )
+
+    answers <- response$answers
+
+    if (!is.null(answers) && length(answers) > 0) {
+      if (is.null(names(answers)) && !is.null(answers$questionId)) {
+        answers <- list(answers)
+        names(answers) <- as.character(extract_form_scalar(answers[[1]]$questionId, NA_character_))
+      }
+
+      for (answer in answers) {
+        question_id <- as.character(extract_form_scalar(answer$questionId, NA_character_))
+        answer_column <- metadata_lookup[[question_id]]
+
+        if (is.null(answer_column) || is.na(answer_column)) {
+          answer_column <- build_google_form_answer_name(question_id, question_id)
+        }
+
+        response_row[[answer_column]] <- extract_single_answer(answer)
+      }
+    }
+
+    response_row
+  })
+
+  info_df <- dplyr::bind_rows(response_rows)
+  info_df <- as.data.frame(info_df, stringsAsFactors = FALSE, check.names = FALSE)
+
+  info_df
 }
 
 
@@ -274,10 +441,10 @@ next_google <- function(page_result) {
   )
 
   result <- request_google_forms(
-    token = token,
-    url = url,
+    token = page_result$request_info$token,
+    url = page_result$request_info$url,
     body_params = body_params,
-    query_params = query_params,
+    query_params = page_result$request_info$query_params,
     return_request = TRUE
   )
 

--- a/R/google-forms.R
+++ b/R/google-forms.R
@@ -179,13 +179,22 @@ extract_google_form_rows <- function(df) {
 
   if (is.data.frame(df)) {
     return(lapply(seq_len(nrow(df)), function(i) {
-        if (is.list(col(df))) {
-            message("evalued the if")
-            df[col(df)[[i,min(ncol(df), i)]],]
+      lapply(df, function(col) {
+        if (is.data.frame(col)) {
+          # A nested JSON object was parsed into a data.frame column.
+          # `col[[i]]` would index by COLUMN, not row, and error out once
+          # `i` exceeds ncol(col). Slice out row `i` instead, keeping it as
+          # a one-row data.frame so downstream code (which already knows
+          # how to walk data.frames/lists via extract_form_scalar()) works.
+          as.list(col[i, , drop = FALSE])
+        } else if (is.list(col)) {
+          # A genuine list column: each element already corresponds to a row.
+          col[[i]]
         } else {
-            message("went to the else")
-            df[i,]
+          # A plain atomic vector column.
+          col[[i]]
         }
+      })
     }))
   }
 
@@ -399,10 +408,18 @@ extract_answers <- function(form_info, metadata = NULL) {
 
       for (answer in answers) {
         question_id <- as.character(extract_form_scalar(answer$questionId, NA_character_))
-        answer_column <- metadata_lookup[[question_id]]
+
+        # `metadata_lookup` is a named atomic vector, not a list, so using
+        # `[[` with a name that isn't present throws "subscript out of
+        # bounds" instead of returning NULL. Single-bracket indexing (`[`)
+        # returns a length-1 named vector with NA when the name is missing,
+        # which lets the fallback below actually run instead of crashing.
+        answer_column <- metadata_lookup[question_id]
 
         if (is.null(answer_column) || is.na(answer_column)) {
           answer_column <- build_google_form_answer_name(question_id, question_id)
+        } else {
+          answer_column <- unname(answer_column)
         }
 
         response_row[[answer_column]] <- extract_single_answer(answer)

--- a/R/write-data.R
+++ b/R/write-data.R
@@ -6,7 +6,8 @@
 #' @param token OAuth token from Google login.
 #' @param gsheet Optionally a googlesheet to write to
 #' @param overwrite TRUE/FALSE overwrite if there is data at the destination
-#' @param append_rows TRUE/FALSE should the data be appended to the data?
+#' @param append_rows TRUE/FALSE should the data be appended to the data? Appending
+#' adds rows as-is and does not deduplicate existing data.
 #' @param sheet Index or name of the worksheet you want to write to. Forwarded to googlesheets4::write_sheet or googlesheets4::append_sheet to indicate what sheet it should be written to.
 #' @param new_sheet default is FALSE. But if it is anything else will be used as the name for a new worksheet that will be made and written to.
 #' @param ... these parameters are sent to googlesheets4::write_sheet.
@@ -86,7 +87,13 @@ write_to_gsheet <- function(input, token = NULL, gsheet = NULL, overwrite = FALS
   if (append_rows == FALSE) gsheet_output <- googlesheets4::write_sheet(data = input, ss = gsheet, sheet = sheet, ...)
 
   # We've been told to append
-  if (append_rows == TRUE) gsheet_output <- googlesheets4::sheet_append(data = input, ss = gsheet, sheet = sheet, ...)
+  if (append_rows == TRUE) {
+    warning(
+      "append_rows = TRUE appends rows as-is and does not deduplicate existing data.",
+      call. = FALSE
+    )
+    gsheet_output <- googlesheets4::sheet_append(data = input, ss = gsheet, sheet = sheet, ...)
+  }
 
   return(gsheet_output)
 }

--- a/man/extract_answers.Rd
+++ b/man/extract_answers.Rd
@@ -4,10 +4,12 @@
 \alias{extract_answers}
 \title{Google Form handling functions -- extracting answers}
 \usage{
-extract_answers(form_info)
+extract_answers(form_info, metadata = NULL)
 }
 \arguments{
 \item{form_info}{The return form_info list that is extracted in `get_google_form()`}
+
+\item{metadata}{Optional metadata returned by `get_question_metadata()`}
 }
 \value{
 This returns answers from a google form

--- a/man/write_to_gsheet.Rd
+++ b/man/write_to_gsheet.Rd
@@ -24,7 +24,8 @@ write_to_gsheet(
 
 \item{overwrite}{TRUE/FALSE overwrite if there is data at the destination}
 
-\item{append_rows}{TRUE/FALSE should the data be appended to the data?}
+\item{append_rows}{TRUE/FALSE should the data be appended to the data? Appending
+adds rows as-is and does not deduplicate existing data.}
 
 \item{sheet}{Index or name of the worksheet you want to write to. Forwarded to googlesheets4::write_sheet or googlesheets4::append_sheet to indicate what sheet it should be written to.}
 

--- a/tests/testthat/test-google-forms.R
+++ b/tests/testthat/test-google-forms.R
@@ -1,3 +1,139 @@
+mock_google_form_payload <- function() {
+  form_metadata <- list(result = list(items = data.frame(
+    itemId = c("item_q1", "item_q2", "item_note", "group_item", "item_upload"),
+    title = c(
+      "Favorite option",
+      "Favorite pangram",
+      "Section note",
+      "Grid prompt",
+      "Upload your files"
+    ),
+    questionItem = I(list(
+      list(question = list(questionId = "304b2bf0", choiceQuestion = list(type = "RADIO"))),
+      list(question = list(questionId = "60b89270", textQuestion = list(paragraph = TRUE))),
+      NULL,
+      NULL,
+      list(question = list(questionId = "fileq1", fileUploadQuestion = list()))
+    )),
+    questionGroupItem = I(list(
+      NULL,
+      NULL,
+      NULL,
+      list(questions = data.frame(
+        questionId = c("gridrow1", "gridrow2"),
+        rowQuestion = I(list(
+          list(title = "Row 1"),
+          list(title = "Row 2")
+        )),
+        choiceQuestion = I(list(
+          list(type = "RADIO"),
+          list(type = "RADIO")
+        )),
+        stringsAsFactors = FALSE,
+        check.names = FALSE
+      )),
+      NULL
+    )),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )))
+
+  responses <- data.frame(
+    responseId = c("resp1", "resp2"),
+    answers = I(list(
+      list(
+        "304b2bf0" = list(
+          questionId = "304b2bf0",
+          textAnswers = list(answers = list(list(value = "Option A")))
+        ),
+        "60b89270" = list(
+          questionId = "60b89270",
+          textAnswers = list(answers = list(list(value = "The quick brown fox")))
+        ),
+        "gridrow1" = list(
+          questionId = "gridrow1",
+          textAnswers = list(answers = list(list(value = "Column 1")))
+        ),
+        "fileq1" = list(
+          questionId = "fileq1",
+          fileUploadAnswers = list(answers = list(
+            list(fileName = "notes.txt"),
+            list(fileName = "plot.png")
+          ))
+        )
+      ),
+      list(
+        "304b2bf0" = list(
+          questionId = "304b2bf0",
+          textAnswers = list(answers = list(
+            list(value = "Option B"),
+            list(value = "Option C")
+          ))
+        ),
+        "60b89270" = list(
+          questionId = "60b89270",
+          textAnswers = list(answers = data.frame(
+            value = "Farmer Jack realized that big yellow quilts were expensive.",
+            stringsAsFactors = FALSE
+          ))
+        ),
+        "gridrow2" = list(
+          questionId = "gridrow2",
+          textAnswers = list(answers = list(list(value = "Column 2")))
+        )
+      )
+    )),
+    stringsAsFactors = FALSE,
+    check.names = FALSE
+  )
+
+  list(
+    form_metadata = form_metadata,
+    response_info = list(result = list(responses = responses))
+  )
+}
+
+
+test_that("Google Forms metadata uses question IDs and readable answer names", {
+  payload <- mock_google_form_payload()
+  metadata <- get_question_metadata(payload$form_metadata)
+
+  expect_equal(
+    metadata$question_id,
+    c("304b2bf0", "60b89270", "gridrow1", "gridrow2", "fileq1")
+  )
+  expect_equal(
+    metadata$item_id,
+    c("item_q1", "item_q2", "group_item", "group_item", "item_upload")
+  )
+  expect_false("item_note" %in% metadata$item_id)
+  expect_true(all(grepl("_answers$", metadata$answer_column)))
+  expect_true(any(grepl("^favorite_option__", metadata$answer_column)))
+  expect_true(any(grepl("^grid_prompt_row_1__", metadata$answer_column)))
+})
+
+
+test_that("Google Forms answers align to metadata and preserve readable names", {
+  payload <- mock_google_form_payload()
+  metadata <- get_question_metadata(payload$form_metadata)
+  answers <- extract_answers(payload, metadata = metadata)
+
+  favorite_option_col <- metadata$answer_column[metadata$question_id == "304b2bf0"]
+  pangram_col <- metadata$answer_column[metadata$question_id == "60b89270"]
+  upload_col <- metadata$answer_column[metadata$question_id == "fileq1"]
+
+  expect_true(all(c("response_id", metadata$answer_column) %in% names(answers)))
+  expect_false(any(grepl("^X", names(answers)[-1])))
+  expect_equal(answers[[favorite_option_col]][1], "Option A")
+  expect_equal(answers[[favorite_option_col]][2], "Option B|Option C")
+  expect_equal(answers[[pangram_col]][1], "The quick brown fox")
+  expect_equal(
+    answers[[upload_col]][1],
+    "notes.txt|plot.png"
+  )
+})
+
+
 auth_tokens <-
   c(
     Sys.getenv("METRICMINER_GOOGLE_REFRESH"),


### PR DESCRIPTION
### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

Now the function does three main things better:

- It uses the correct Google question ID in the metadata, so metadata and responses line up properly.
- It gives response columns readable names based on the question title, while still keeping the underlying question ID in the name so the columns stay stable and traceable.
- It parses the response payload more carefully, so it handles multiple-answer questions and file upload answers more reliably.

I tested this by creating some new unit tests and then running them. 